### PR TITLE
Add InfraScan to Others category

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,3 +224,4 @@ A curated list of awesome softwares for Devops.
 * [Carbon](https://carbon.now.sh/) - Create and share beautiful images of your source code.
 * [CodeLF](https://github.com/unbug/codelf) - Search over projects from GitHub, Bitbucket, GitLab to find real-world usage and variable names.
 * [Cloud 66](https://www.cloud66.com/) - DevOps as a service that helps to build, deploy and manage any application on any cloud or server.
+* [InfraScan](https://infrascan.soldevelo.com) - An Advanced Infrastructure Auditor by SolDevelo. Comprehensive scans for AWS cost antipatterns, IaC security issues, and container vulnerabilities.


### PR DESCRIPTION
## Description

This PR adds **[InfraScan](https://infrascan.soldevelo.com)** to the "Others" category in the [README.md](cci:7://file:///home/user/Pulpit/awesome-dev/awesome-dev/README.md:0:0-0:0).

InfraScan is an Advanced Infrastructure Auditor developed by SolDevelo. It helps developers and DevOps engineers to run comprehensive scans directly from a GitHub repository for:
- AWS cost antipatterns (e.g., oversized instances, unmanaged disks, or missing lifecycle rules).
- IaC security issues (identifying open ports, unencrypted storage, risky IAM policies before deploying to production).
- Container vulnerabilities.

The tool currently requires no complex setup or cloud credentials for the initial scan. It's a valuable addition to the list for anyone looking to optimize infrastructure costs, improve security, and maintain high standards within their environments.

## Changes made
- Added InfraScan with a short description to the `Others` section in `README.md`.