### PR TITLE
Add Regen — open-source self-hosted incident management

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ A curated list of awesome softwares for Devops.
 * [Telegraf](https://www.influxdata.com/time-series-platform/telegraf/) - Telegraf is a server-based agent for collecting and sending all metrics and events from databases, systems, and IoT sensors. Telegraf is written in Go and compiles into a single binary with no external dependencies, and requires a very minimal memory footprint.
 * [Splunk](https://www.splunk.com/) - Splunk's core offering collects and analyzes high volumes of machine-generated data. It uses an API to connect to applications and devices.
 * [Middleware](https://middleware.io/) - A full-stack cloud observability platform to monitor your data with ease and get the right insights faster.
+* [Regen](https://github.com/FluidifyAI/Regen) - Open-source, self-hosted incident management with alert ingestion from Prometheus/Grafana, on-call scheduling, escalation policies, and Slack/Teams integration.
 
 ## Application Definition
 


### PR DESCRIPTION
Add Regen to the Monitor section — open-source, self-hosted incident management that ingests alerts from Prometheus, Grafana, and CloudWatch, then manages the full incident lifecycle with on-call scheduling, escalation policies, and Slack/Teams integration. AGPLv3. https://github.com/FluidifyAI/Regen